### PR TITLE
fix: prevent example content for overflowing

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -33,6 +33,7 @@ $controls-breakpoint: math.div($controls-width, $controls-ratio);
         grid-area: example;
         padding: var(--live-example-space);
         background: repeating-conic-gradient(#fff 0 90deg, rgb(235, 235, 235) 0 180deg) 0 0/20px 20px round;
+        overflow: hidden;
     }
 
     &__controls {


### PR DESCRIPTION
Utan detta trycker exempel bort inställningarna (exemplet är fortfarande för brett så det klipps av ändå):

![image](https://github.com/user-attachments/assets/1f6cd6e2-664f-414e-ac24-c038851444a3)

Efter ändringen:

![image](https://github.com/user-attachments/assets/22c81842-6de9-4983-b159-23c0a4bf001b)
