### PR TITLE
fix: prevent overflow in live-example grid

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -20,7 +20,7 @@ $controls-breakpoint: math.div($controls-width, $controls-ratio);
         border: var(--f-border-width-small) solid #ddddde;
         border-radius: 4px;
         display: grid;
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
         grid-template-areas: "example" "controls" "code";
 
         @container example-container (width >= #{$controls-breakpoint}) {
@@ -33,7 +33,7 @@ $controls-breakpoint: math.div($controls-width, $controls-ratio);
         grid-area: example;
         padding: var(--live-example-space);
         background: repeating-conic-gradient(#fff 0 90deg, rgb(235, 235, 235) 0 180deg) 0 0/20px 20px round;
-        overflow: hidden;
+        overflow: auto;
     }
 
     &__controls {


### PR DESCRIPTION
Före:
![image](https://github.com/user-attachments/assets/474c70c3-062c-4f7a-9089-844cab35e3a8)

Efter:
![image](https://github.com/user-attachments/assets/cf769a15-bf07-4528-b226-0ef3b3072789)
