### PR TITLE
feat!: require prettier v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [16.x, 18.x, 20.x, 21.x]
+                node-version: [20.x, 22.x]
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                version: [2.x, 3.x]
+                version: [3.x]
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
@@ -36,10 +36,6 @@ jobs:
               run: npm ci
             - name: Install prettier v${{ matrix.version }}
               run: |
-                  # not used for this compatibility test and conflicts with prettier v2
-                  npm rm @forsakringskassan/eslint-config
-                  npm rm @forsakringskassan/prettier-config
-
                   npm install --no-save $(npx -y npm-min-peer prettier --major ${{ matrix.version }} --with-name)
                   npm ls prettier
             - name: Jest

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@tsconfig/node20": "20.1.5",
         "@types/jest": "29.5.14",
         "@types/node": "20.17.30",
-        "@types/prettier": "2.7.3",
         "esbuild": "0.25.2",
         "html-validate": "9.5.2",
         "html-validate-vue": "7.1.5",
@@ -44,7 +43,7 @@
       },
       "peerDependencies": {
         "html-validate": ">= 7.9.0",
-        "prettier": "^2.3 || ^3",
+        "prettier": "^3.0.0",
         "vue": "^3.4.15"
       },
       "peerDependenciesMeta": {
@@ -3033,13 +3032,6 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
-    },
-    "node_modules/@types/prettier": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.com/@types/prettier/-/prettier-2.7.3.tgz",
-      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "@tsconfig/node20": "20.1.5",
     "@types/jest": "29.5.14",
     "@types/node": "20.17.30",
-    "@types/prettier": "2.7.3",
     "esbuild": "0.25.2",
     "html-validate": "9.5.2",
     "html-validate-vue": "7.1.5",
@@ -119,7 +118,7 @@
   },
   "peerDependencies": {
     "html-validate": ">= 7.9.0",
-    "prettier": "^2.3 || ^3",
+    "prettier": "^3.0.0",
     "vue": "^3.4.15"
   },
   "peerDependenciesMeta": {

--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -1,6 +1,6 @@
 import { type Options } from "prettier";
-import prettier from "prettier/standalone";
-import htmlPlugin from "prettier/parser-html";
+import { format } from "prettier/standalone";
+import htmlPlugin from "prettier/plugins/html";
 import hljs from "highlight.js/lib/core";
 import html from "highlight.js/lib/languages/xml";
 
@@ -19,10 +19,7 @@ const prettierConfig: Options = {
  * @internal
  */
 export async function highlight(code: string): Promise<string> {
-    /* eslint-disable-next-line import/no-named-as-default-member -- technical
-     * debt, without actually checking this is probably needed for compatibility
-     * with prettier 2 */
-    const formatted = await prettier.format(code, prettierConfig);
+    const formatted = await format(code, prettierConfig);
     const { value } = hljs.highlight(formatted, { language: "html" });
     return `<code class="hljs lang-html" tabindex="0">${value}</code>`;
 }


### PR DESCRIPTION
Kan verka trivialt men behövs för att vi ska kunna köra live-exempel från Vite devserver.

Importen `"prettier/parser-html"` resolvar till en commonjs fil i Prettier 3 vilket lirar i andra byggverktyg men inte i Vite. Prettier 3 har funnits ganska länge nu och mig veterligen har vi själva migrerat allt till det så känner att det är lika bra släppa kompatibiliteten här och då kan vi köra på nya importen som fungerar out-of-the-box med Vite.
