### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete multi-character sanitization

### DIFF
--- a/src/utils/strip-comments.ts
+++ b/src/utils/strip-comments.ts
@@ -3,5 +3,13 @@
  */
 export function stripComments(html: string): string {
     const commentPattern = /<!--.*?-->/g;
-    return html.replaceAll(commentPattern, "");
+    let previous: string;
+    let current = html;
+
+    do {
+        previous = current;
+        current = current.replace(commentPattern, "");
+    } while (current !== previous);
+
+    return current;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Forsakringskassan/docs-live-example/security/code-scanning/9](https://github.com/Forsakringskassan/docs-live-example/security/code-scanning/9)

General fix: avoid one-pass removal of multi-character unsafe substrings. Either use a dedicated sanitizer library, or repeatedly apply the replacement until the string stabilizes.

Best fix here (minimal behavior change, no new deps): keep the existing regex intent, but run replacement in a loop until no further change occurs. This directly addresses the CodeQL finding while preserving current functionality (removing HTML comments rather than stripping all tags/chars).

File/region to change:
- `src/utils/strip-comments.ts`, inside `stripComments` (lines 4–7 shown).

Implementation details:
- Keep `commentPattern` as-is.
- Replace the single `return html.replaceAll(...)` with a `do...while` fixed-point loop:
  - Track `previous` and `current`.
  - Reapply `replace` (or `replaceAll`) until `current === previous`.
  - Return `current`.
- No imports or external dependencies needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
